### PR TITLE
[#docker] Fix docker-compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,9 +6,6 @@ services:
         target: production
       environment:
         - NODE_ENV=production
-      dns:
-        - 8.8.8.8
-        - 8.8.4.4
       ports:
         - "3000:3000"
       healthcheck:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -47,6 +47,7 @@ services:
       # Run the container as a non-root user for better security
       # forcing using user wayback:tomba
       user: 653:504
+      # On ansible we still require this volume because we add logs and upload folders bellow
       volumes:
         - ./logs:/home/node/app/logs
         - ./uploads:/home/node/app/uploads

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -47,6 +47,6 @@ services:
       # Run the container as a non-root user for better security
       # forcing using user wayback:tomba
       user: 653:504
-      # On ansible we still require this volume because we add logs and upload folders bellow
       volumes:
-        - ./:/home/node/app
+        - ./logs:/home/node/app/logs
+        - ./uploads:/home/node/app/uploads

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,6 @@ services:
         target: development
       environment:
         - NODE_ENV=development
-      dns:
-        - 8.8.8.8
-        - 8.8.4.4
       volumes:
         - ./:/home/node/app
         - /home/node/app/node_modules


### PR DESCRIPTION
Mounting the entire project directory is unnecessary and breaks the application. The compiled files must come from the multistage build, not the project root.