### PR TITLE
refactor: simplify API clients and increase timeout to 3 minutes

### DIFF
--- a/src/apis/api-request.js
+++ b/src/apis/api-request.js
@@ -42,20 +42,17 @@ class ApiRequest {
         this.logger = logger('ApiRequest');
         this.options = { 
             method: 'GET',
-            timeout: 30000, // 30 second timeout
-            maxRetries: process.env.NODE_ENV === 'test' ? 0 : 2, // Disable retries in test environment
-            retryDelay: 500
+            timeout: 180000 // 3 minutes
         };
     }
 
     /**
-     * Performs a GET request to the configured API URL with retry logic
+     * Performs a GET request to the configured API URL
      * 
      * @param {URLSearchParams} requestData - Query parameters for the request
      * @param {Function} callback - Callback function(data) invoked with response data
-     * @param {number} attempt - Current retry attempt (internal use)
      */
-    get(requestData, callback, attempt = 0) {
+    get(requestData, callback) {
         let apiReply = '';
         let callbackInvoked = false;
 
@@ -100,26 +97,8 @@ class ApiRequest {
             });
 
             apiReq.on('error', (e) => {
-                // Retry on DNS failures (EAI_AGAIN) or connection resets
-                const isRetryableError = e.code === 'EAI_AGAIN' || 
-                                        e.code === 'ECONNRESET' || 
-                                        e.code === 'ENOTFOUND' ||
-                                        e.code === 'ETIMEDOUT';
-                
-                // Only retry if not already retrying and retries are enabled
-                const shouldRetry = isRetryableError && 
-                                   attempt < this.options.maxRetries && 
-                                   !callbackInvoked;
-                
-                if (shouldRetry) {
-                    this.logger.info(`${this.apiUrl} : Retrying after ${e.message} (attempt ${attempt + 1}/${this.options.maxRetries + 1})`);
-                    setTimeout(() => {
-                        this.get(requestData, callback, attempt + 1);
-                    }, this.options.retryDelay * (attempt + 1)); // Exponential backoff
-                } else {
-                    this.logger.error(`${this.apiUrl} : Request error: ${e.message}`);
-                    safeCallback(this.defaultApiReply);
-                }
+                this.logger.error(`${this.apiUrl} : Request error: ${e.message}`);
+                safeCallback(this.defaultApiReply);
             });
 
             apiReq.on('timeout', () => {

--- a/src/apis/base-api-request.js
+++ b/src/apis/base-api-request.js
@@ -35,9 +35,7 @@ class BaseApiRequest {
         this.logger = logger(loggerName);
         this.options = options || { 
             method: 'GET',
-            timeout: 30000,
-            maxRetries: process.env.NODE_ENV === 'test' ? 0 : 2,
-            retryDelay: 500
+            timeout: 180000 // 3 minutes
         };
     }
 
@@ -67,9 +65,8 @@ class BaseApiRequest {
      * 
      * @param {URLSearchParams} requestData - Query parameters for the request
      * @param {Function} callback - Callback function invoked with response data
-     * @param {number} attempt - Current retry attempt (internal use)
      */
-    get(requestData, callback, attempt = 0) {
+    get(requestData, callback) {
         // Validate callback
         if (typeof callback !== 'function') {
             return;
@@ -96,35 +93,16 @@ class BaseApiRequest {
 
             // Handle request errors
             apiReq.on('error', (e) => {
-                // Retry on DNS failures (EAI_AGAIN) or connection resets
-                const isRetryableError = e.code === 'EAI_AGAIN' || 
-                                        e.code === 'ECONNRESET' || 
-                                        e.code === 'ENOTFOUND' ||
-                                        e.code === 'ETIMEDOUT';
-                
-                // Only retry if we haven't exceeded max retries
-                const shouldRetry = isRetryableError && attempt < this.options.maxRetries;
-                
-                if (shouldRetry) {
-                    this.logger.info(`${this.apiUrl} : Retrying after ${e.message} (attempt ${attempt + 1}/${this.options.maxRetries + 1})`);
-                    if (!apiReq.destroyed) {
-                        apiReq.destroy();
-                    }
-                    setTimeout(() => {
-                        this.get(requestData, callback, attempt + 1);
-                    }, this.options.retryDelay * (attempt + 1)); // Exponential backoff
-                } else {
-                    this.logger.error(`${this.apiUrl} : Request error: ${e.message}`);
-                    if (!apiReq.destroyed) {
-                        apiReq.destroy();
-                    }
-                    safeCallback(this.defaultApiReply);
+                this.logger.error(`${this.apiUrl} : Request error: ${e.message}`);
+                if (!apiReq.destroyed) {
+                    apiReq.destroy();
                 }
+                safeCallback(this.defaultApiReply);
             });
 
             // Handle timeout
             apiReq.on('timeout', () => {
-                this.logger.error(`${this.apiUrl} : Timeout (${this.options.timeout || 120000} ms)`);
+                this.logger.error(`${this.apiUrl} : Timeout (${this.options.timeout}ms)`);
                 apiReq.destroy();
                 safeCallback(this.defaultApiReply);
             });


### PR DESCRIPTION
- Remove retry logic and fail fast on errors
- Increase timeout from 30s to 180s (3 minutes) in ApiRequest and BaseApiRequest
- Remove maxRetries, retryDelay, and attempt parameters
- Simplify error handling for better visibility into actual failures

This addresses production timeouts where the backend responds in ~1 minute but the UI receives empty results.