### PR TITLE
dead-code: remove commented-out morgan block from server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -51,9 +51,6 @@ try {
     createParentPath: true
   }));
 
-  // const morgan = require('morgan')
-  // app.use(morgan('combined'))
-
   app.use((req,res,next) => {
     // clear language headers to prevent auto-detect browser language
     let requestLanguage = '';


### PR DESCRIPTION
## Dead-code purge — item 2 of 7

Closes #54 (partially)

### What was removed
Two commented-out lines in `server.js`:
```js
// const morgan = require('morgan')
// app.use(morgan('combined'))
```

### Why it is safe
Logging is already handled by `express-winston` via `traffic-logger.js`. These lines have been commented out (dead) and serve no purpose. `morgan` is also listed as an unused dependency in #54 item 3.