### PR TITLE
ci: add development branch to CI triggers and latest tag condition

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -6,12 +6,14 @@ on:
     branches:
       - main
       - master
+      - development
     tags:
       - '*'
   pull_request:
     branches:
       - main
       - master
+      - development
 
 jobs:
   build-and-push:
@@ -42,7 +44,7 @@ jobs:
             arquivo/arquivo-webapp
           # generate Docker tags based on the following events/attributes
           tags: |
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/development' }}
             type=schedule
             type=ref,event=branch
             type=ref,event=pr


### PR DESCRIPTION
## Summary

- Add `development` to `push` and `pull_request` branch triggers so CI runs on the active development branch
- Update the `latest` Docker tag condition to also fire on `development`

## Why

The repository's default branch is `development`, but CI only triggered on `main`/`master`, meaning pushes and PRs to `development` ran no tests and built no image. This aligns CI with where active work lands.

Closes #51