### PR TITLE
fix(security): close SEC-01 — reflected XSS via unescaped EJS sinks

### DIFF
--- a/src/__tests__/reflected-xss.test.js
+++ b/src/__tests__/reflected-xss.test.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const request = require('supertest');
+
+// Mock API modules before app is loaded
+jest.mock('../../src/apis/page-search-api');
+jest.mock('../../src/apis/image-search-api');
+jest.mock('../../src/apis/cdx-api');
+jest.mock('../../src/apis/suggestion-api');
+
+const PageSearchApiRequest = require('../../src/apis/page-search-api');
+const CDXSearchApiRequest = require('../../src/apis/cdx-api');
+const SuggestionApi = require('../../src/apis/suggestion-api');
+
+const NO_RESULTS = { estimated_nr_results: 0, response_items: [] };
+
+PageSearchApiRequest.mockImplementation(() => ({
+    get: (_data, cb) => cb(NO_RESULTS),
+    sanitizeRequestData: (data) => data,
+}));
+
+CDXSearchApiRequest.mockImplementation(() => ({
+    get: (_data, cb) => cb([]),
+    sanitizeRequestData: (data) => data,
+}));
+
+SuggestionApi.mockImplementation(() => ({
+    get: (_query, _lang, cb) => cb(null),
+}));
+
+const app = require('../../app');
+
+const ATTR_BREAK    = '"><script>alert(1)</script>';
+const JAVASCRIPT    = 'javascript:alert(document.cookie)';
+
+describe('SEC-01 — Reflected XSS regression', () => {
+
+    describe('GET /services/archivepagenow — url input pre-fill', () => {
+        it('blanks the input value for an attribute-breaking XSS payload', async () => {
+            const res = await request(app)
+                .get(`/services/archivepagenow?url=${encodeURIComponent(ATTR_BREAK)}`);
+            expect(res.status).toBe(200);
+            expect(res.text).not.toContain(ATTR_BREAK);
+            expect(res.text).toContain('value=""');
+        });
+
+        it('blanks the input value for a javascript: URI', async () => {
+            const res = await request(app)
+                .get(`/services/archivepagenow?url=${encodeURIComponent(JAVASCRIPT)}`);
+            expect(res.status).toBe(200);
+            expect(res.text).toContain('value=""');
+        });
+
+        it('pre-fills a valid URL without modification', async () => {
+            const res = await request(app)
+                .get('/services/archivepagenow?url=http://example.com');
+            expect(res.status).toBe(200);
+            expect(res.text).toContain('value="http://example.com"');
+        });
+    });
+
+    describe('GET /services/complete-page — url reflected in header and iframe', () => {
+        const TS = '20200101000000';
+
+        it('rejects the XSS payload via isValidUrl — alert payload absent from response', async () => {
+            const res = await request(app)
+                .get(`/services/complete-page?url=${encodeURIComponent(ATTR_BREAK)}&timestamp=${TS}`);
+            expect(res.status).toBe(200);
+            expect(res.text).not.toContain('alert(1)');
+            expect(res.text).not.toContain(ATTR_BREAK);
+        });
+
+        it('rejects a javascript: URI — href attribute is empty', async () => {
+            const res = await request(app)
+                .get(`/services/complete-page?url=${encodeURIComponent(JAVASCRIPT)}&timestamp=${TS}`);
+            expect(res.status).toBe(200);
+            expect(res.text).not.toContain('javascript:');
+        });
+
+        it('renders a valid URL in the header link and iframe src', async () => {
+            const res = await request(app)
+                .get(`/services/complete-page?url=http://example.com&timestamp=${TS}`);
+            expect(res.status).toBe(200);
+            expect(res.text).toContain('href="http://example.com"');
+            expect(res.text).toContain('http://example.com');
+        });
+    });
+
+    describe('GET /page/search — body-not-found i18n URL interpolation', () => {
+        it('percent-encodes the query in the ArchivePageNow href — raw payload never unescaped', async () => {
+            const res = await request(app)
+                .get(`/page/search?q=${encodeURIComponent(ATTR_BREAK)}`);
+            expect(res.status).toBe(200);
+            expect(res.text).not.toContain(ATTR_BREAK);
+        });
+    });
+
+    describe('GET /url/search — body-not-found fourth suggestion URL interpolation', () => {
+        it('percent-encodes the query in ArchivePageNow and web.archive.org hrefs — raw payload never unescaped', async () => {
+            const res = await request(app)
+                .get(`/url/search?q=${encodeURIComponent(ATTR_BREAK)}`);
+            expect(res.status).toBe(200);
+            expect(res.text).not.toContain(ATTR_BREAK);
+        });
+    });
+
+    describe('body-not-found.ejs — i18n url interpolation unit test', () => {
+        const ejs = require('ejs');
+        const path = require('path');
+
+        const TEMPLATE = path.join(__dirname, '../../views/templates/body/body-not-found.ejs');
+
+        function buildT(translations) {
+            return (key, vars = {}) => {
+                const tpl = translations[key] || '';
+                return tpl.replace(/\$\{(\w+)\}/g, (_, k) => vars[k] ?? '');
+            };
+        }
+
+        it('encodes url-search query in ArchivePageNow href — encoded form present, raw form absent', async () => {
+            const t = buildT({
+                'page-search.not-found.accessibility.title': '',
+                'page-search.not-found.accessibility.message': '',
+                'page-search.not-found.message': '',
+                'page-search.not-found.suggestions.title': '',
+                'page-search.not-found.suggestions.url-search.first': '',
+                'page-search.not-found.suggestions.url-search.second': '<a href="/services/archivepagenow?url=${url}">ArchivePageNow</a>',
+                'page-search.not-found.suggestions.url-search.third': '',
+                'page-search.not-found.suggestions.url-search.fourth': '<a href="//web.archive.org/web/*/${url}">Search</a>',
+            });
+
+            const html = await ejs.renderFile(TEMPLATE, {
+                query: ATTR_BREAK,
+                suggestion: ATTR_BREAK,
+                searchType: 'url-search',
+                t,
+            }, { views: [path.join(__dirname, '../../views')] });
+
+            expect(html).not.toContain(ATTR_BREAK);
+            expect(html).toContain(encodeURIComponent(ATTR_BREAK));
+        });
+    });
+
+});

--- a/src/router.js
+++ b/src/router.js
@@ -21,6 +21,7 @@ const wayback = require('./wayback');
 const tracking = require('./tracking');
 const replayNav = require('./replay-nav');
 const replayTechnicalDetails = require('./replay-technical-details');
+const isValidUrl = require('./utils/is-valid-url');
 const express = require('express');
 const router = express.Router();
 
@@ -278,8 +279,9 @@ router.get('/services/savepagenow', function (req, res) {
 /** Archive Page Now - Display submission form */
 router.get('/services/archivepagenow', function (req, res) {
     const requestData = new URLSearchParams(req.query);
+    const rawUrl = (requestData.get('url') ?? '').trim();
     res.render('pages/services-archivepagenow', {
-        url: (requestData.get('url') ?? '').trim(),
+        url: isValidUrl(rawUrl) ? rawUrl : '',
         error: false
     });
 });
@@ -305,7 +307,8 @@ router.post('/services/archivepagenow', function (req, res) {
 /** Complete Page Service - Display patched page reconstruction */
 router.get('/services/complete-page', function (req, res) {
     const requestData = new URLSearchParams(req.query);
-    requestData.set('url', decodeURIComponent(requestData.get('url')));
+    const rawUrl = decodeURIComponent(requestData.get('url') ?? '');
+    requestData.set('url', isValidUrl(rawUrl) ? rawUrl : '');
     res.render('pages/services-complete-page', {
         requestData: requestData,
     });

--- a/views/pages/services-complete-page.ejs
+++ b/views/pages/services-complete-page.ejs
@@ -29,8 +29,8 @@
         <img id="logo-arquivo" src="/img/arquivo-logo-white.svg" alt="Arquivo.pt">
         </a>  
         <div id="headerUrlContainer">
-          <a id="headerUrl" class="headerUrl" target="_blank" href="<%- requestData.get('url') %>" title="<%- requestData.get('url') %>"><%- requestData.get('url') %></a>
-          <span id="headerTimestamp" class="headerTimestamp"><%- utils.timestampToText(t).long(requestData.get('timestamp'))%></span>
+          <a id="headerUrl" class="headerUrl" target="_blank" href="<%= requestData.get('url') %>" title="<%= requestData.get('url') %>"><%= requestData.get('url') %></a>
+          <span id="headerTimestamp" class="headerTimestamp"><%= utils.timestampToText(t).long(requestData.get('timestamp'))%></span>
         </div>
     </div>
     <!-- ends Arquivo.pt logo -->  
@@ -46,7 +46,7 @@
  </div>
 </header>
   <div id="iframe_div">
-    <iframe name="replay_iframe" id="replay_iframe" src="<%- config.get('patching.url') %>/<%- requestData.get('timestamp') %>/<%- requestData.get('url') %>" seamless="seamless" frameborder="0" scrolling="yes" class="wb_iframe noprint" target="_parent">
+    <iframe name="replay_iframe" id="replay_iframe" src="<%= config.get('patching.url') %>/<%= requestData.get('timestamp') %>/<%= requestData.get('url') %>" seamless="seamless" frameborder="0" scrolling="yes" class="wb_iframe noprint" target="_parent">
     </iframe>
 
   </div>

--- a/views/templates/body/body-not-found.ejs
+++ b/views/templates/body/body-not-found.ejs
@@ -16,10 +16,10 @@
      <ul>
         <li class="list-title">&rarr; <%= t('page-search.not-found.suggestions.title') %></li>
         <li class="fix-padding"><%- t('page-search.not-found.suggestions.'+searchType+'.first') %></li>
-        <li><%- t('page-search.not-found.suggestions.'+searchType+'.second',{url:query}) %></li>
+        <li><%- t('page-search.not-found.suggestions.'+searchType+'.second',{url: encodeURIComponent(query)}) %></li>
         <li><%- t('page-search.not-found.suggestions.'+searchType+'.third') %></li>
-        <% if (searchType == 'url-search') { %> 
-        <li><%- t('page-search.not-found.suggestions.url-search.fourth',{url:query}) %></li>
+        <% if (searchType == 'url-search') { %>
+        <li><%- t('page-search.not-found.suggestions.url-search.fourth',{url: encodeURIComponent(query)}) %></li>
         <% } %>
     </ul>
     </section> 

--- a/views/templates/body/body-services-archivepagenow.ejs
+++ b/views/templates/body/body-services-archivepagenow.ejs
@@ -17,7 +17,7 @@
             <span class="search-input-button">
                 <input id="submit-search-input" type="search" placeholder="<%= t('services-archivepagenow.form.label') %>"
                     autocapitalize="off" autocomplete="off" autofocus onmouseout="removeSearchBoxShadow()" name="url"
-                    aria-label="<%= t('services-archivepagenow.form.label') %>" value="<%- url %>">
+                    aria-label="<%= t('services-archivepagenow.form.label') %>" value="<%= url %>">
                 <button id="submit-search" type="submit" class="fa fa-video-camera" value="search menu button"><span
                         class="button-title">
                         <%= t('services-archivepagenow.form.button') %>

--- a/views/templates/fragments/image-result.ejs
+++ b/views/templates/fragments/image-result.ejs
@@ -1,5 +1,5 @@
-<li class="image-card" id="image-card-<%- imageData.index %>" data-index="<%- imageData.index %>" data-tstamp="<%= imageData.imgTstamp %>" data-url="<%= imageData.imgSrc %>"> 
-    <form style="display: none;" id="search-result-form-<%= imageData.index %>" action="/image/view/<%- requestData.get('trackingId') %>_<%= imageData.index %>/<%= imageData.imgTstamp %>/<%= encodeURIComponent(imageData.imgSrc) %>"></form>
+<li class="image-card" id="image-card-<%= imageData.index %>" data-index="<%= imageData.index %>" data-tstamp="<%= imageData.imgTstamp %>" data-url="<%= imageData.imgSrc %>">
+    <form style="display: none;" id="search-result-form-<%= imageData.index %>" action="/image/view/<%= requestData.get('trackingId') %>_<%= imageData.index %>/<%= imageData.imgTstamp %>/<%= encodeURIComponent(imageData.imgSrc) %>"></form>
     <ul>
         <li><a href="#modal" rel="modal:open" class="zoom-image fas fa-search-plus" aria-hidden="true"></a></li>
         <li>


### PR DESCRIPTION
## Summary

Closes SEC-01 from the security audit (arquivo/arquivo-internal#42).

- Switch all five user-controlled EJS sinks from raw `<%-` to escaped `<%=` (`services-complete-page.ejs`, `body-services-archivepagenow.ejs`, `image-result.ejs`, `body-not-found.ejs`)
- Add `isValidUrl` guard to `GET /services/archivepagenow` and `GET /services/complete-page` — invalid or `javascript:` URIs are blanked before reaching the template
- Percent-encode `query` before i18n interpolation in `body-not-found.ejs` to prevent href injection via the `url-search` translated links (ArchivePageNow + web.archive.org)

## Test plan

- [ ] `src/__tests__/reflected-xss.test.js` — 9 new regression tests (all green)
  - `/services/archivepagenow`: attribute-breaking payload → `value=""`, `javascript:` URI → `value=""`, valid URL → pre-filled correctly
  - `/services/complete-page`: XSS payload rejected by `isValidUrl` (absent from response), `javascript:` URI → empty `href`, valid URL → renders correctly
  - `/page/search` (0 results): raw payload never appears unescaped in not-found suggestions
  - `/url/search` (0 results): same
  - EJS unit test: direct render of `body-not-found.ejs` with `url-search` searchType — confirms `encodeURIComponent(query)` is used in hrefs