### PR TITLE
fix: source SESSION_SECRET from env and fail-fast in production (SEC-02)

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,9 @@ const cookies = require('cookie-parser');
 const path = require('path');
 const router = require('./src/router');
 const trafficLogger = require('./src/logger/traffic-logger');
+const { validateSessionSecret } = require('./src/utils/session-secret-validator');
+
+validateSessionSecret(config.get('session.secret'), process.env.NODE_ENV);
 
 const app = express();
 

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -1,0 +1,5 @@
+{
+  "session": {
+    "secret": "SESSION_SECRET"
+  }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,6 +6,7 @@ services:
         target: production
       environment:
         - NODE_ENV=production
+        - SESSION_SECRET  # Required: set this in the host shell or a secrets manager; app refuses to start if unset
       ports:
         - "3000:3000"
       healthcheck:

--- a/src/utils/__tests__/session-secret-validator.test.js
+++ b/src/utils/__tests__/session-secret-validator.test.js
@@ -1,0 +1,49 @@
+const { validateSessionSecret } = require('../session-secret-validator');
+
+const PLACEHOLDER = 'dontWorryThisIsDifferentInProduction';
+
+describe('validateSessionSecret', () => {
+    describe('in production', () => {
+        it('throws when secret equals the placeholder', () => {
+            expect(() => validateSessionSecret(PLACEHOLDER, 'production')).toThrow(
+                /SESSION_SECRET/
+            );
+        });
+
+        it('throws when secret is empty string', () => {
+            expect(() => validateSessionSecret('', 'production')).toThrow(
+                /SESSION_SECRET/
+            );
+        });
+
+        it('throws when secret is undefined', () => {
+            expect(() => validateSessionSecret(undefined, 'production')).toThrow(
+                /SESSION_SECRET/
+            );
+        });
+
+        it('throws when secret is null', () => {
+            expect(() => validateSessionSecret(null, 'production')).toThrow(
+                /SESSION_SECRET/
+            );
+        });
+
+        it('does not throw with a strong secret', () => {
+            expect(() => validateSessionSecret('a-very-strong-random-secret-value', 'production')).not.toThrow();
+        });
+    });
+
+    describe('outside production', () => {
+        it('does not throw with placeholder in development', () => {
+            expect(() => validateSessionSecret(PLACEHOLDER, 'development')).not.toThrow();
+        });
+
+        it('does not throw with placeholder when NODE_ENV is undefined', () => {
+            expect(() => validateSessionSecret(PLACEHOLDER, undefined)).not.toThrow();
+        });
+
+        it('does not throw with empty secret in test environment', () => {
+            expect(() => validateSessionSecret('', 'test')).not.toThrow();
+        });
+    });
+});

--- a/src/utils/session-secret-validator.js
+++ b/src/utils/session-secret-validator.js
@@ -1,0 +1,14 @@
+const PLACEHOLDER = 'dontWorryThisIsDifferentInProduction';
+
+function validateSessionSecret(secret, nodeEnv) {
+    if (nodeEnv !== 'production') return;
+    if (!secret || secret === PLACEHOLDER) {
+        throw new Error(
+            'SESSION_SECRET is not set or still uses the committed placeholder. ' +
+            'Set SESSION_SECRET to a strong, unique value before starting in production. ' +
+            'The placeholder value is burned and must not be reused.'
+        );
+    }
+}
+
+module.exports = { validateSessionSecret };


### PR DESCRIPTION
## Summary

Closes arquivo/arquivo-internal#43

The committed placeholder `dontWorryThisIsDifferentInProduction` was used in production with no override — any repo reader could forge signed session cookies (7-day lifetime).

- **`config/custom-environment-variables.json`** — maps the `SESSION_SECRET` env var to `session.secret` via the `config` package, so the env var overrides the placeholder at runtime
- **`src/utils/session-secret-validator.js`** — throws at startup when `NODE_ENV=production` and the secret is missing or still equals the burned placeholder
- **`app.js`** — calls the validator before the Express app is instantiated; a bad secret causes a hard crash with a clear error message
- **`docker-compose.prod.yml`** — exposes `SESSION_SECRET` as a pass-through env var (must be set on the host or via a secrets manager)

## Test plan

- [ ] `src/utils/__tests__/session-secret-validator.test.js` — 8 unit tests: placeholder/empty/null/undefined all throw in production; placeholder passes in development/test/undefined env
- [ ] Full Jest suite passes (285 tests, 17 suites)
- [ ] Manually verify: starting with `NODE_ENV=production` and no `SESSION_SECRET` crashes with a descriptive error
- [ ] Manually verify: starting with `NODE_ENV=production SESSION_SECRET=<strong-secret>` boots normally
- [ ] **Ops action required**: rotate the session secret — the committed value is burned; generate a new one and set `SESSION_SECRET` in the production environment before deploying