### PR TITLE
ci: bound the boot smoke curl with --max-time (follow-up to #93)

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -41,7 +41,7 @@ jobs:
           APP_PID=$!
           ok=0
           for i in $(seq 1 20); do
-            if curl -sf -o /dev/null http://localhost:3000/; then
+            if curl -sf --max-time 2 -o /dev/null http://localhost:3000/; then
               echo "App responded on / (attempt $i)"; ok=1; break
             fi
             sleep 1


### PR DESCRIPTION
Follow-up to #93 (merged), addressing @igobranco's review suggestion.

## What
Adds `--max-time 2` to the boot-smoke `curl`:
```sh
curl -sf --max-time 2 -o /dev/null http://localhost:3000/
```

## Why
Without it, if the app accepts the TCP connection but never sends a response, that single probe hangs **indefinitely** and stalls the loop (and the CI step) until the job-level timeout. With `--max-time 2` the worst case is bounded: ~20 × (1s sleep + 2s timeout) ≈ 60s, and the step always terminates.

Verified locally: app boots, smoke passes with the flag (`SMOKE PASSED`). One-line, additive.