### PR TITLE
ci: bound smoke-test curl probe with --max-time 2

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -41,7 +41,7 @@ jobs:
           APP_PID=$!
           ok=0
           for i in $(seq 1 20); do
-            if curl -sf -o /dev/null http://localhost:3000/; then
+            if curl -sf --max-time 2 -o /dev/null http://localhost:3000/; then
               echo "App responded on / (attempt $i)"; ok=1; break
             fi
             sleep 1


### PR DESCRIPTION
## Why

The smoke-test loop added in #93 is bounded to ~20s by its `seq 1 20` iteration count, but each individual `curl` call had no timeout flag. If the app accepted the TCP connection and then stalled without sending a response, that single probe would hang indefinitely — stalling the entire loop and the CI job with it.

## What changed

Added `--max-time 2` to the `curl` invocation:

```sh
curl -sf --max-time 2 -o /dev/null http://localhost:3000/
```

This caps each probe at 2 seconds, giving a hard worst-case of **60s** (20 × (1s sleep + 2s curl timeout)) regardless of app behavior.

## Scope

One-character change to the workflow. No application code touched.

Follows up on review comment left on #93.