### PR TITLE
chore: ignore .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ config/service_account.json
 uploads
 coverage
 *.log
+.claude/
 .scannerwork


### PR DESCRIPTION
## Summary

- Adds `.claude/` to `.gitignore`

## Why

The `.claude/` directory contains machine-specific Claude Code configuration (`additionalDirectories` with absolute paths) and ephemeral worktree copies of the repo. Neither is meaningful to other contributors and both would cause noise in git history.

## Reviewers

No functional code change — `.gitignore` only.