### PR TITLE
ci: split monolithic workflow into CI and Docker Publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+description: Run quality checks for pull requests and branch updates
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - development
+  pull_request:
+    branches:
+      - main
+      - master
+      - development
+
+jobs:
+  quality-checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm run test
+
+      - name: Smoke test (boot the app and verify it serves)
+        run: |
+          node server.js &
+          APP_PID=$!
+          ok=0
+          for i in $(seq 1 20); do
+            if curl -sf --max-time 2 -o /dev/null http://localhost:3000/; then
+              echo "App responded on / (attempt $i)"; ok=1; break
+            fi
+            sleep 1
+          done
+          kill "$APP_PID" 2>/dev/null || true
+          if [ "$ok" -ne 1 ]; then
+            echo "::error::App failed to serve / on :3000 — boot smoke test failed"
+            exit 1
+          fi
+
+      - name: SonarCloud analysis
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
+        uses: SonarSource/sonarqube-scan-action@v8.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,5 +1,5 @@
-name: Build and Push Docker Images
-description: This workflow builds and pushes Docker images
+name: Docker Publish
+description: Build Docker images on PRs and publish on non-PR events
 
 on:
   push:
@@ -16,7 +16,7 @@ on:
       - development
 
 jobs:
-  build-and-push:
+  docker-build:
     runs-on: ubuntu-latest
 
     steps:
@@ -25,50 +25,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Run tests
-        run: npm run test
-
-      - name: Smoke test (boot the app and verify it serves)
-        run: |
-          node server.js &
-          APP_PID=$!
-          ok=0
-          for i in $(seq 1 20); do
-            if curl -sf --max-time 2 -o /dev/null http://localhost:3000/; then
-              echo "App responded on / (attempt $i)"; ok=1; break
-            fi
-            sleep 1
-          done
-          kill "$APP_PID" 2>/dev/null || true
-          if [ "$ok" -ne 1 ]; then
-            echo "::error::App failed to serve / on :3000 — boot smoke test failed"
-            exit 1
-          fi
-
-      - name: SonarCloud analysis
-        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
-        uses: SonarSource/sonarqube-scan-action@v8.2.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
-          # list of Docker images to use as base name for tags
           images: |
             arquivo/arquivo-webapp
-          # generate Docker tags based on the following events/attributes
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/development' }}
             type=schedule


### PR DESCRIPTION
## Summary

The previous `build-and-push.yml` mixed quality checks and Docker publishing into a single job. This PR splits it into two focused workflows:

### `ci.yml` — CI quality gate
- Runs on `push` and `pull_request` targeting `main`, `master`, `development`
- Steps: install → test → boot smoke test → SonarCloud analysis
- This is the place to add future CI steps (e.g. accessibility checks, linting)

### `docker-publish.yml` — Docker build & publish
- Runs on `push`/tags **and** `pull_request`
- **On PRs:** builds the image only (`push: false`) to validate the Dockerfile and build context
- **On non-PR events (push/tag):** builds and publishes to Docker Hub

## Why
- **Separation of concerns** — quality checks and image publishing have different triggers, risk profiles and failure modes
- **Safer PR validation** — Docker changes are now caught on every PR without leaking unreviewed images
- **Extensibility** — CI workflow can grow (accessibility, ESLint, etc.) without touching Docker logic
- **Narrower secret scope** — Docker Hub credentials are only exercised on non-PR events